### PR TITLE
BOJ 1260 /  BOJ 2606 / BOJ 1697

### DIFF
--- a/Graph/Graph_Search/BOJ_S1_1697/1697_sainkr.swift
+++ b/Graph/Graph_Search/BOJ_S1_1697/1697_sainkr.swift
@@ -1,0 +1,42 @@
+import Foundation
+struct Location{
+  var index: Int
+  var time: Int
+}
+
+var line = readLine()!.split(separator: " ").map{Int(String($0))!}
+let n = line[0]
+let k = line[1]
+
+func bfs(_ s: Int, _ e: Int, _ time: Int){
+  var queue: [Location] = [Location(index: s, time: 0)]
+  var visit = Array(repeating: false, count: 100005)
+  visit[s] = true
+  while !queue.isEmpty{
+    let location = queue.removeFirst()
+    if location.index == e{
+      print(location.time)
+      break
+    }
+    if location.index * 2 <= 100000, !visit[location.index * 2]{
+      queue.append(Location(index: location.index * 2, time: location.time + 1))
+      visit[location.index * 2] = true
+    }
+    if location.index - 1 >= 0, !visit[location.index - 1]{
+      queue.append(Location(index: location.index - 1, time: location.time + 1))
+      visit[location.index - 1] = true
+    }
+    if location.index + 1 <= 100000, !visit[location.index + 1]{
+      queue.append(Location(index: location.index + 1, time: location.time + 1))
+      visit[location.index + 1] = true
+    }
+  }
+}
+
+if k == n{
+  print(0)
+}else if n > k{
+  print(n - k)
+}else{
+  bfs(n,k,0)
+}

--- a/Graph/Graph_Search/BOJ_S2_1260/1260_sainkr.swift
+++ b/Graph/Graph_Search/BOJ_S2_1260/1260_sainkr.swift
@@ -1,0 +1,57 @@
+import Foundation
+let lineArr = readLine()!.split(separator: " ").map{Int(String($0))!}
+let n = lineArr[0]
+let m = lineArr[1]
+let v = lineArr[2]
+
+var graph: [Int: [Int]] = [:]
+var dfsArr: [Int] = []
+var bfsArr: [Int] = []
+
+for _ in 1...m{
+  let lineArr = readLine()!.split(separator: " ").map{Int(String($0))!}
+  if graph[lineArr[0]] == nil{
+    graph[lineArr[0]] = [lineArr[1]]
+  }else {
+    graph[lineArr[0]]?.append(lineArr[1])
+  }
+  if graph[lineArr[1]] == nil{
+    graph[lineArr[1]] = [lineArr[0]]
+  }else {
+    graph[lineArr[1]]?.append(lineArr[0])
+  }
+}
+
+func dfs(_ s: Int){
+  var list: [Int] = []
+  var stack = [s]
+  while !stack.isEmpty{
+    let node = stack.removeLast()
+    if !list.contains(node){
+      list.append(node)
+      print(node, terminator: " ")
+      if let nearNode = graph[node]{
+        stack.append(contentsOf: nearNode.sorted(by: >))
+      }
+    }
+  }
+}
+
+func bfs(_ s: Int){
+  var list: [Int] = []
+  var queue: [Int] = [s]
+  while !queue.isEmpty{
+    let node = queue.removeFirst()
+    if !list.contains(node){
+      list.append(node)
+      print(node, terminator: " ")
+      if let nearNode = graph[node]{
+        queue.append(contentsOf: nearNode.sorted())
+      }
+    }
+  }
+}
+
+dfs(v)
+print()
+bfs(v)

--- a/Graph/Graph_Search/BOJ_S3_2606/2606_sainkr.swift
+++ b/Graph/Graph_Search/BOJ_S3_2606/2606_sainkr.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+let firstLine = readLine()!.components(separatedBy: " ").map{Int($0)!}
+let n = firstLine[0]
+let secondLine = readLine()!.components(separatedBy: " ").map{Int($0)!}
+let v = secondLine[0]
+var graph: [Int : [Int]] = [:]
+
+for _ in 1...v{
+  let line = readLine()!.components(separatedBy: " ").map{Int($0)!}
+  if graph[line[0]] == nil {
+    graph[line[0]] = [line[1]]
+  }else {
+    graph[line[0]]?.append(line[1])
+  }
+  if graph[line[1]] == nil {
+    graph[line[1]] = [line[0]]
+  }else {
+    graph[line[1]]?.append(line[0])
+  }
+}
+
+func dfs()-> Int{
+  var visit: [Int] = []
+  var stack: [Int] = [1]
+  while !stack.isEmpty{
+    let computer = stack.removeLast()
+    if !visit.contains(computer){
+      visit.append(computer)
+      if let nearNode = graph[computer]{
+        stack.append(contentsOf: nearNode)
+      }
+    }
+  }
+  return visit.count - 1
+}
+
+print(dfs())


### PR DESCRIPTION
## 문제번호:
- 1260(https://www.acmicpc.net/problem/1260)

## 시간복잡도(optional):
- DFS : O(V + E), BFS : O(V + E)  // V: 정점의 개수, E: 간선의 개수

## 알고리즘 분류 및 이유:
- 문제 조건에 DFS 탐색 , BFS 탐색 명시

## 문제 풀이(로직) 설명:
[참고 사이트](https://icksw.tistory.com/28)
1. input을 통해 grpah를 구합니다.
-> graph는 Dictionary 타입이며 각 노드와 연결된 노드들을 나타냅니다.
2. Stack을 활용하여 DFS 탐색을 합니다.
-> 우선 시작할 정점 v를 stack에 넣어줍니다.
-> stack에서 마지막 값을 꺼내 방문한 곳인지 체크해줍니다.
-> 방문하지 않았다면 해당 노드와 연결된 노드를 내림차순으로 정렬한 후 stack에 넣어줍니다. 내림차순으로 정렬하는 이유는 정점번호가 작은 노드를 먼저 방문해야되기 때문.
-> 위 과정을 stack이 비어있을 때까지 반복합니다.
3. Queue를 활용하여 bfs 탐색을 합니다.
-> 우선 시작할 정점 v를 queue에 넣어줍니다.
-> queue에서 첫번째 값을 꺼내 방문한 곳인지 체크해줍니다.
-> 방문하지 않았다면 해당 노드와 연결된 노드를 오름차순으로 정렬한 후 queue에 넣어줍니다.
-> 위 과정을 queue가 비어있을 때까지 반복합니다.
***
## 문제번호:
- 2606(https://www.acmicpc.net/problem/2606)

## 시간복잡도(optional):
- O(V + E) 

## 알고리즘 분류 및 이유:
- 노드들은 그래프로 연결되어 있고 방문 경로를 찾으면 되므로 DFS 혹은 BFS가 적합함.

## 문제 풀이(로직) 설명:
- Stack을 활용하여 DFS탐색 후 방문 노드.count - 1(1번 노드 제외)값을 출력한다.
***
## 문제번호:
- 1697(https://www.acmicpc.net/problem/1697)

## 시간복잡도(optional):
-  O(V + E)

## 알고리즘 분류 및 이유:
- 한 노드당 간선이 세개( -1, + 1, *2)씩 있는 그래프를 탐색하는 문제이기 때문에 DFS 혹은 BFS가 적합하다고 생각. 
- 각 노드당 간선이 세개씩 있어 탐색해야 될 부분이 많아 DFS보단 BFS를 활용하는게 효율적임.

## 문제 풀이(로직) 설명:
1. Location Strcut를 생성해준다.
     Location은 위치와 시간의 값을 갖고 있다.
2. 방문 한 위치를 체크하기 위해  visit를 생성해준다. 중요한 점은 크기를 100001로 설정하면 런타임에러가 발생해 100005이상으로 설정해야된다. (이유는 모르겠음 😅 )
3. Queue를 활용한 Bfs 탐색
    ->  queue의 첫번째 값을 꺼내 해당 위치가 동생이 있는 위치 k와 같은지 확인한다.
   -> 현재 위치 * 2, 현재위치 + 1, 현재 위치 - 1 의 위치를 방문하지 않았다면 해당 위치와 time +1을 queue에 넣어준 후 해당 위치 방문 표시.
   -> 위 과정을 해당 위치가 동생의 위치와 같을 때 까지 반복해준다.